### PR TITLE
Feature/common fe routes

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,19 +3,20 @@ Spree AMS
 
 [![Build Status](https://travis-ci.org/hhff/spree_ams.svg)](https://travis-ci.org/hhff/spree_ams)
 [![Dependency Status](https://gemnasium.com/hhff/spree_ams.svg)](https://gemnasium.com/hhff/spree_ams)
+[![Code Climate](https://codeclimate.com/github/vinsol/spree_ams/badges/gpa.svg)](https://codeclimate.com/github/vinsol/spree_ams)
 
 Spree AMS is a module namspaced under Spree's Api module, providing a Spree Application with a collection of routes that behave identically to the regular api routes, but instead respond with serialized models (via the [Active Model Serializers](https://github.com/rails-api/active_model_serializers) gem).
 
-This gem does not modify Spree's existing API - it can be used alongside this gem.
+> This gem does not modify Spree's existing API - it can be used alongside this gem. However, its response is different from `spree_api`. Instead of sending the association objects nested within the parent object, this gem sends them at the root of serialized object. See this for more information on `embed` options of ActiveModel::Serializer : http://www.rubydoc.info/gems/active_model_serializers/0.8.2/ActiveModel/Serializer.embed.
 
 
 Installation
 ------------
 
-Add spree_ams to your Spree store's Gemfile:
+Add `spree_ams` to your Spree store's Gemfile:
 
 ```ruby
-gem 'spree_ams', :github => 'hhff/spree_ams', :branch => '3-0-alpha'
+gem 'spree_ams', github: 'vinsol/spree_ams', branch: '3-1-stable'
 ```
 
 If you'd like to explicitly set the host URL for the Image Serializer to output absolute URLs  you'll need to set a config.action_controller.asset_host in your Rails environment configuration.
@@ -37,6 +38,17 @@ rails g spree:api:ams:install
 
 Then run ```bundle``` and you're good to go!
 
+CORS Restrictions
+-------
+
+If you happen to use `spree_ams` for developing a seperate front end application, you'll need to set proper headers so the browsers can allow the cross origin requests. To do this, open `config/initializers/spree_ams.rb` in your editor:
+
+```ruby
+  config.cors_whitelist = 'http://localhost:4200'
+```
+
+Set this to whatever address your FE server is running on. Remember to restart your rails server after making this change.
+
 
 Testing
 -------
@@ -56,5 +68,14 @@ Generate docs from the Acceptance Tests (you'll need to generate your dummy test
 ```ruby
 rake app:docs:generate
 ```
+
+
+1. Fork It
+2. Clone it.
+3. Create your feature branch (`git checkout -b my-new-feature`)
+4. Commit your changes (`git commit -am 'Add my feature'`)
+5. Push to the branch (`git push origin my-new-feature`)
+6. Create a new Pull Request
+
 
 Copyright (c) 2014 Hugh Francis, released under the New BSD License

--- a/app/controllers/spree/api/ams/orders_controller.rb
+++ b/app/controllers/spree/api/ams/orders_controller.rb
@@ -5,10 +5,16 @@ module Spree
         include Serializable
         include Requestable
 
-        def order_id
-          super || params[:id]
+        def mine
+          super
+          respond_with @orders
         end
 
+        private
+
+          def order_id
+            super || params[:id]
+          end
       end
     end
   end

--- a/app/serializers/spree/order_serializer.rb
+++ b/app/serializers/spree/order_serializer.rb
@@ -12,7 +12,6 @@ module Spree
                 :completed_at,
                 :ship_address_id,
                 :payment_total,
-                :shipping_method_id,
                 :shipment_state,
                 :payment_state,
                 :email,

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,7 +6,10 @@ Spree::Core::Engine.routes.draw do
       resources :products
       resources :line_items
       resources :orders do
-        get :mine, on: :collection
+        collection do
+          get :mine
+          get :current
+        end
         put :empty, on: :member
       end
       resources :taxonomies

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,7 +5,10 @@ Spree::Core::Engine.routes.draw do
 
       resources :products
       resources :line_items
-      resources :orders
+      resources :orders do
+        get :mine, on: :collection
+        put :empty, on: :member
+      end
       resources :taxonomies
       resources :taxons
       resources :countries, :only => [:index, :show]


### PR DESCRIPTION
1. Remove `shipping_method_id` from OrderSerializer. See commit https://github.com/spree/spree/commit/009a188e8673221be58c51314803abc5433eb418

2. Add a few routes useful for implementing most front end applications. orders#mine, orders#current, orders#empty.

3. Update Readme.